### PR TITLE
HLCM specs with interaction variables, and lottery choices to utils

### DIFF
--- a/configs/hlcm/hlcm1.yaml
+++ b/configs/hlcm/hlcm1.yaml
@@ -18,50 +18,74 @@ sample_size: 100
 
 estimation_sample_size: 3000
 
-prediction_sample_size: null
-
 model_expression:
-- year_built
-- b_ln_building_sqft
-- nodes_walk_max_medical_far
-- land_area
-- nodes_drv_drv_15min_retail_jobs
-- nodes_walk_ln_popden
-- building_type_id_is_84
+- residential_units
+- b_is_pre_1945
+- has_children:nodes_walk_percent_hh_with_children
+- has_workers:zones_a_ln_emp_50min_transit
+- drv_nearest_healthcenter
+- b_ln_land_area
+- nodes_drv_drv_60min_jobs
+- is_race1:nodes_walk_percent_race1
+- persons:nodes_walk_ln_popden
+- nodes_walk_ave_nonres_sqft_price
+- is_young:nodes_walk_retail_jobs
+- ln_income:nodes_walk_ln_popden
+- sqft_price_res
 
 fitted: true
 
-choice_mode: aggregate
-
 fit_parameters:
     Coefficient:
-        b_ln_building_sqft: 0.8445379773973224
-        building_type_id_is_84: 0.3666844672491216
-        land_area: 3.546936022323104e-05
-        nodes_drv_drv_15min_retail_jobs: -0.003107614736936102
-        nodes_walk_ln_popden: 0.6659339859633742
-        nodes_walk_max_medical_far: 0.1263965178028475
-        year_built: -8.870305422923271e-05
+        b_is_pre_1945: 0.6153700811177055
+        b_ln_land_area: 1.0384403657496137
+        drv_nearest_healthcenter: -0.07237738013832011
+        has_children:nodes_walk_percent_hh_with_children: 2.7923560806922922
+        has_workers:zones_a_ln_emp_50min_transit: 0.02850740052832018
+        is_race1:nodes_walk_percent_race1: 3.0
+        is_young:nodes_walk_retail_jobs: 0.0012140173324791152
+        ln_income:nodes_walk_ln_popden: 0.021476605976995116
+        nodes_drv_drv_60min_jobs: 0.05245541335248602
+        nodes_walk_ave_nonres_sqft_price: 0.0009769380426933182
+        persons:nodes_walk_ln_popden: 0.16755056943411303
+        residential_units: 0.024823869541042022
+        sqft_price_res: -0.005424589941875864
     Std. Error:
-        b_ln_building_sqft: 0.01359040736494747
-        building_type_id_is_84: 0.10286264084508277
-        land_area: 2.74228693074184e-06
-        nodes_drv_drv_15min_retail_jobs: 0.013772520802082978
-        nodes_walk_ln_popden: 0.033275088268234124
-        nodes_walk_max_medical_far: 0.013323102363469608
-        year_built: 2.608667180000697e-05
+        b_is_pre_1945: 0.03932261071068326
+        b_ln_land_area: 0.02166979405621244
+        drv_nearest_healthcenter: 0.00544260031908733
+        has_children:nodes_walk_percent_hh_with_children: 0.1940329108559774
+        has_workers:zones_a_ln_emp_50min_transit: 0.003968819583617031
+        is_race1:nodes_walk_percent_race1: 0.07237849344412992
+        is_young:nodes_walk_retail_jobs: 0.000653542479804631
+        ln_income:nodes_walk_ln_popden: 0.002434834379578761
+        nodes_drv_drv_60min_jobs: 0.012469846156176623
+        nodes_walk_ave_nonres_sqft_price: 0.0003399631741086958
+        persons:nodes_walk_ln_popden: 0.006733035760927874
+        residential_units: 0.0008234515644813316
+        sqft_price_res: 0.00034946239470845736
     T-Score:
-        b_ln_building_sqft: 62.14221212938504
-        building_type_id_is_84: 3.5647973281316987
-        land_area: 12.934226475577416
-        nodes_drv_drv_15min_retail_jobs: -0.22563877605224608
-        nodes_walk_ln_popden: 20.01298931486545
-        nodes_walk_max_medical_far: 9.487018440195431
-        year_built: -3.4003208576882935
+        b_is_pre_1945: 15.649268194456893
+        b_ln_land_area: 47.92109989858933
+        drv_nearest_healthcenter: -13.298308877190724
+        has_children:nodes_walk_percent_hh_with_children: 14.391146679054579
+        has_workers:zones_a_ln_emp_50min_transit: 7.1828411263632255
+        is_race1:nodes_walk_percent_race1: 41.44877652524982
+        is_young:nodes_walk_retail_jobs: 1.857595137261822
+        ln_income:nodes_walk_ln_popden: 8.820561331449033
+        nodes_drv_drv_60min_jobs: 4.206580634236899
+        nodes_walk_ave_nonres_sqft_price: 2.8736584344896237
+        persons:nodes_walk_ln_popden: 24.884847694767483
+        residential_units: 30.146119834841606
+        sqft_price_res: -15.522671463409917
 
-probability_mode: single_chooser
+probability_mode: full_product
+
+choice_mode: individual
+
+prediction_sample_size: 100
 
 log_likelihoods:
-    convergence: -11695.865902454854
+    convergence: -10986.736569072726
     'null': -13815.51055796495
-    ratio: 0.15342499624728478
+    ratio: 0.2047534889878806

--- a/configs/hlcm/hlcm2.yaml
+++ b/configs/hlcm/hlcm2.yaml
@@ -18,17 +18,20 @@ sample_size: 100
 
 estimation_sample_size: 3000
 
-prediction_sample_size: null
-
 model_expression:
-- b_is_newerthan2010
-- nodes_walk_hhs_with_children
-- b_ln_building_sqft
-- b_ln_parcels_parcel_far
-- nodes_walk_sum_residential_units
-- nodes_drv_drv_10min_pop
-- nodes_walk_retail
-- nodes_walk_percent_mid_income
+- has_children:nodes_walk_percent_hh_with_children
+- parcels_pct_undev
+- b_ln_land_area
+- parcels_pptytax
+- building_type_id_is_83
+- persons:nodes_walk_ln_popden
+- nodes_walk_sum_nonresidential_units
+- is_race2:nodes_walk_percent_race2
+- is_young:nodes_walk_retail_jobs
+- ln_income:nodes_walk_ln_popden
+- crime_ucr_rate
+- sqft_price_res
+- nodes_walk_race_3_hhs
 
 fitted: true
 
@@ -36,36 +39,55 @@ choice_mode: aggregate
 
 fit_parameters:
     Coefficient:
-        b_is_newerthan2010: 0.5029426307730395
-        b_ln_building_sqft: 0.7780705150350777
-        b_ln_parcels_parcel_far: 0.3818291566181057
-        nodes_drv_drv_10min_pop: 0.050052274292020436
-        nodes_walk_hhs_with_children: -0.000276928749048701
-        nodes_walk_percent_mid_income: 3.0
-        nodes_walk_retail: 0.0007512246795854039
-        nodes_walk_sum_residential_units: 0.247003533299515
+        b_ln_land_area: 0.7264616978373304
+        building_type_id_is_83: 1.5311146223212393
+        crime_ucr_rate: -3.0514146136774014e-05
+        has_children:nodes_walk_percent_hh_with_children: 2.511304466965783
+        is_race2:nodes_walk_percent_race2: 3.0
+        is_young:nodes_walk_retail_jobs: 0.002050865600406377
+        ln_income:nodes_walk_ln_popden: 0.009085060839684784
+        nodes_walk_race_3_hhs: 0.0017918290791519701
+        nodes_walk_sum_nonresidential_units: 0.06834948985650442
+        parcels_pct_undev: 0.0023096130381268735
+        parcels_pptytax: -0.0031747446275852695
+        persons:nodes_walk_ln_popden: 0.04239786403105645
+        sqft_price_res: -0.0024659102041211163
     Std. Error:
-        b_is_newerthan2010: 0.1832107204824203
-        b_ln_building_sqft: 0.015538992912117341
-        b_ln_parcels_parcel_far: 0.1218246846923013
-        nodes_drv_drv_10min_pop: 0.012210933424719031
-        nodes_walk_hhs_with_children: 0.0003480269284302902
-        nodes_walk_percent_mid_income: 0.21468191489521196
-        nodes_walk_retail: 0.0002625356490908682
-        nodes_walk_sum_residential_units: 0.02145000156163417
+        b_ln_land_area: 0.009414189024043156
+        building_type_id_is_83: 0.05766695581239565
+        crime_ucr_rate: 1.2596847993614553e-05
+        has_children:nodes_walk_percent_hh_with_children: 0.18532485946224664
+        is_race2:nodes_walk_percent_race2: 0.1180066090689454
+        is_young:nodes_walk_retail_jobs: 0.0005937781144688073
+        ln_income:nodes_walk_ln_popden: 0.0031526368674789805
+        nodes_walk_race_3_hhs: 0.0005792537830253533
+        nodes_walk_sum_nonresidential_units: 0.012542258267791609
+        parcels_pct_undev: 0.0007683227076350368
+        parcels_pptytax: 0.0019529859564729774
+        persons:nodes_walk_ln_popden: 0.007114751103950479
+        sqft_price_res: 0.0002680112754113201
     T-Score:
-        b_is_newerthan2010: 2.745159395960667
-        b_ln_building_sqft: 50.072132694541395
-        b_ln_parcels_parcel_far: 3.134251137874977
-        nodes_drv_drv_10min_pop: 4.098972007389527
-        nodes_walk_hhs_with_children: -0.7957106948526538
-        nodes_walk_percent_mid_income: 13.974162665096056
-        nodes_walk_retail: 2.861419705045054
-        nodes_walk_sum_residential_units: 11.515315399384848
+        b_ln_land_area: 77.1666785085789
+        building_type_id_is_83: 26.550987489305314
+        crime_ucr_rate: -2.422363606534102
+        has_children:nodes_walk_percent_hh_with_children: 13.550823533619742
+        is_race2:nodes_walk_percent_race2: 25.422304934185924
+        is_young:nodes_walk_retail_jobs: 3.4539258865091003
+        ln_income:nodes_walk_ln_popden: 2.881733996516285
+        nodes_walk_race_3_hhs: 3.0933403141426594
+        nodes_walk_sum_nonresidential_units: 5.449536151876669
+        parcels_pct_undev: 3.0060455264117607
+        parcels_pptytax: -1.6255849751826912
+        persons:nodes_walk_ln_popden: 5.959149295822162
+        sqft_price_res: -9.200770379293386
 
-probability_mode: single_chooser
+probability_mode: full_product
+
+choice_mode: individual
+
+prediction_sample_size: 100
 
 log_likelihoods:
-    convergence: -12575.025071829334
+    convergence: -11985.9333689045
     'null': -13815.51055796495
-    ratio: 0.08978933358495744
+    ratio: 0.13242921290416287

--- a/configs/hlcm/hlcm3.yaml
+++ b/configs/hlcm/hlcm3.yaml
@@ -18,54 +18,50 @@ sample_size: 100
 
 estimation_sample_size: 3000
 
-prediction_sample_size: null
-
 model_expression:
-- b_is_newerthan2010
-- b_ln_building_sqft
-- nodes_walk_medical
-- nodes_walk_population
-- nodes_drv_drv_15min_retail_jobs
-- nodes_walk_ave_lot_sqft
-- crime08
+- has_children:nodes_drv_elem_school_perf
 - sqft_price_res
+- is_race2:nodes_walk_percent_race2
+- is_young:nodes_walk_retail_jobs
+- ln_income:nodes_walk_ln_popden
+- crime_ucr_rate
+- parcels_total_units
 
 fitted: true
 
-choice_mode: aggregate
-
 fit_parameters:
     Coefficient:
-        b_is_newerthan2010: 0.5047942105816854
-        b_ln_building_sqft: 0.7148231545661907
-        crime08: -0.006598245548189589
-        nodes_drv_drv_15min_retail_jobs: 0.005696791688018663
-        nodes_walk_ave_lot_sqft: 0.09424658193678591
-        nodes_walk_medical: 0.001131624382105395
-        nodes_walk_population: 0.0003437910565283324
-        sqft_price_res: -0.0017009025822761115
+        crime_ucr_rate: -0.0002037988981567109
+        has_children:nodes_drv_elem_school_perf: 0.27371492332729946
+        is_race2:nodes_walk_percent_race2: 3.0
+        is_young:nodes_walk_retail_jobs: 0.0040722974848643335
+        ln_income:nodes_walk_ln_popden: 0.015892392097297047
+        parcels_total_units: 0.0011601483144176223
+        sqft_price_res: -0.001381255529416692
     Std. Error:
-        b_is_newerthan2010: 0.17890572087324053
-        b_ln_building_sqft: 0.017329182362947355
-        crime08: 0.0009831886224685262
-        nodes_drv_drv_15min_retail_jobs: 0.01553460700038075
-        nodes_walk_ave_lot_sqft: 0.025410972771059817
-        nodes_walk_medical: 0.00032895334132241146
-        nodes_walk_population: 6.988162155512183e-05
-        sqft_price_res: 0.00022378509925567784
+        crime_ucr_rate: 1.2817557900101867e-05
+        has_children:nodes_drv_elem_school_perf: 0.14453182423207642
+        is_race2:nodes_walk_percent_race2: 0.12937898660970837
+        is_young:nodes_walk_retail_jobs: 0.0004421507691821545
+        ln_income:nodes_walk_ln_popden: 0.0015547330490043834
+        parcels_total_units: 0.0001413545556685238
+        sqft_price_res: 0.00020593288163245178
     T-Score:
-        b_is_newerthan2010: 2.821565504544964
-        b_ln_building_sqft: 41.24967581243766
-        crime08: -6.711067843343368
-        nodes_drv_drv_15min_retail_jobs: 0.366716176848184
-        nodes_walk_ave_lot_sqft: 3.7088931142424406
-        nodes_walk_medical: 3.4400756580133813
-        nodes_walk_population: 4.919620479286587
-        sqft_price_res: -7.600606957002104
+        crime_ucr_rate: -15.899978743617865
+        has_children:nodes_drv_elem_school_perf: 1.8938038371936152
+        is_race2:nodes_walk_percent_race2: 23.187691282897134
+        is_young:nodes_walk_retail_jobs: 9.210201064213583
+        ln_income:nodes_walk_ln_popden: 10.221942672071055
+        parcels_total_units: 8.207364162624996
+        sqft_price_res: -6.707309286731351
 
-probability_mode: single_chooser
+probability_mode: full_product
+
+choice_mode: individual
+
+prediction_sample_size: 100
 
 log_likelihoods:
-    convergence: -13107.316572966209
+    convergence: -13262.34260073
     'null': -13815.51055796495
-    ratio: 0.05126078996700212
+    ratio: 0.04003963189880344

--- a/configs/hlcm/hlcm4.yaml
+++ b/configs/hlcm/hlcm4.yaml
@@ -18,58 +18,70 @@ sample_size: 100
 
 estimation_sample_size: 3000
 
-prediction_sample_size: null
-
 model_expression:
-- b_is_pre_1945
-- crime_other_rate
-- b_ln_building_sqft
-- building_type_id_is_81
-- nodes_walk_industrial
+- has_children:nodes_drv_elem_school_perf
+- parcels_ave_unit_size
+- year_built
+- ln_income:nodes_walk_ave_income
+- persons:sqft_per_unit
+- is_race1:nodes_walk_percent_race1
+- nodes_walk_ln_popden
 - stories
-- b_ln_land_area
-- nodes_drv_drv_30min_jobs
-- nodes_walk_percent_hh_with_children
+- crime08
+- zones_logsum_pop_high_income
+- is_young:nodes_walk_retail_jobs
+- nodes_walk_max_industrial_far
 
 fitted: true
 
-choice_mode: aggregate
-
 fit_parameters:
     Coefficient:
-        b_is_pre_1945: -0.19605741833321147
-        b_ln_building_sqft: 0.11340863542032992
-        b_ln_land_area: 0.8762524354952299
-        building_type_id_is_81: 0.17416147401117552
-        crime_other_rate: -7.397352297869432e-05
-        nodes_drv_drv_30min_jobs: 0.025294366105569285
-        nodes_walk_industrial: -0.0016574719661584447
-        nodes_walk_percent_hh_with_children: 0.960476479544499
-        stories: 0.15183924472105126
+        crime08: -0.007841541602032367
+        has_children:nodes_drv_elem_school_perf: 0.4323407560459128
+        is_race1:nodes_walk_percent_race1: 3.0
+        is_young:nodes_walk_retail_jobs: 0.002457083371567294
+        ln_income:nodes_walk_ave_income: 0.016392841052319678
+        nodes_walk_ln_popden: 0.13953566132125347
+        nodes_walk_max_industrial_far: -0.0908207158078686
+        parcels_ave_unit_size: 0.00022532783512908375
+        persons:sqft_per_unit: 2.784242856137901e-05
+        stories: 0.40347735886361974
+        year_built: 0.0001276788584282741
+        zones_logsum_pop_high_income: 1.98434562072794e-07
     Std. Error:
-        b_is_pre_1945: 0.04570214794678114
-        b_ln_building_sqft: 0.02159646112694965
-        b_ln_land_area: 0.02615698550268842
-        building_type_id_is_81: 0.056942550640887574
-        crime_other_rate: 7.126403455194634e-06
-        nodes_drv_drv_30min_jobs: 0.012460598446624706
-        nodes_walk_industrial: 0.0008969078779806792
-        nodes_walk_percent_hh_with_children: 0.1952513458758694
-        stories: 0.018552794814002932
+        crime08: 0.0014115301134853633
+        has_children:nodes_drv_elem_school_perf: 0.14162516624761853
+        is_race1:nodes_walk_percent_race1: 0.08448772089486731
+        is_young:nodes_walk_retail_jobs: 0.0007835418653493843
+        ln_income:nodes_walk_ave_income: 0.0010660201779280002
+        nodes_walk_ln_popden: 0.03029965789100069
+        nodes_walk_max_industrial_far: 0.01861509856412277
+        parcels_ave_unit_size: 3.008358490917898e-05
+        persons:sqft_per_unit: 4.3041958863535455e-06
+        stories: 0.017950153498940195
+        year_built: 2.799782245242178e-05
+        zones_logsum_pop_high_income: 8.500959508770058e-08
     T-Score:
-        b_is_pre_1945: -4.289895051793075
-        b_ln_building_sqft: 5.251260137190268
-        b_ln_land_area: 33.49974848612309
-        building_type_id_is_81: 3.058547115487288
-        crime_other_rate: -10.380204186274769
-        nodes_drv_drv_30min_jobs: 2.0299479366033943
-        nodes_walk_industrial: -1.8479846223339218
-        nodes_walk_percent_hh_with_children: 4.919179815309032
-        stories: 8.184170969564589
+        crime08: -5.555348431547068
+        has_children:nodes_drv_elem_school_perf: 3.0527113753921737
+        is_race1:nodes_walk_percent_race1: 35.508118436915396
+        is_young:nodes_walk_retail_jobs: 3.135867373815018
+        ln_income:nodes_walk_ave_income: 15.377608596660975
+        nodes_walk_ln_popden: 4.605189333266267
+        nodes_walk_max_industrial_far: -4.878873753744666
+        parcels_ave_unit_size: 7.490059306739492
+        persons:sqft_per_unit: 6.468671337578626
+        stories: 22.477655073392086
+        year_built: 4.560313883168797
+        zones_logsum_pop_high_income: 2.3342607604244905
 
-probability_mode: single_chooser
+probability_mode: full_product
+
+choice_mode: individual
+
+prediction_sample_size: 100
 
 log_likelihoods:
-    convergence: -13025.336711511776
+    convergence: -12988.656299501501
     'null': -13815.51055796495
-    ratio: 0.057194690209810606
+    ratio: 0.05984970696481062

--- a/configs/hlcm/no_interactions/hlcm1.yaml
+++ b/configs/hlcm/no_interactions/hlcm1.yaml
@@ -1,0 +1,67 @@
+name: MNLDiscreteChoiceModel
+
+model_type: discretechoice
+
+choosers_fit_filters: building_id>1
+
+choosers_predict_filters: income_quartile == 1
+
+alts_fit_filters: residential_units>0
+
+alts_predict_filters: null
+
+interaction_predict_filters: null
+
+choice_column: building_id
+
+sample_size: 100
+
+estimation_sample_size: 3000
+
+prediction_sample_size: null
+
+model_expression:
+- year_built
+- b_ln_building_sqft
+- nodes_walk_max_medical_far
+- land_area
+- nodes_drv_drv_15min_retail_jobs
+- nodes_walk_ln_popden
+- building_type_id_is_84
+
+fitted: true
+
+choice_mode: aggregate
+
+fit_parameters:
+    Coefficient:
+        b_ln_building_sqft: 0.8445379773973224
+        building_type_id_is_84: 0.3666844672491216
+        land_area: 3.546936022323104e-05
+        nodes_drv_drv_15min_retail_jobs: -0.003107614736936102
+        nodes_walk_ln_popden: 0.6659339859633742
+        nodes_walk_max_medical_far: 0.1263965178028475
+        year_built: -8.870305422923271e-05
+    Std. Error:
+        b_ln_building_sqft: 0.01359040736494747
+        building_type_id_is_84: 0.10286264084508277
+        land_area: 2.74228693074184e-06
+        nodes_drv_drv_15min_retail_jobs: 0.013772520802082978
+        nodes_walk_ln_popden: 0.033275088268234124
+        nodes_walk_max_medical_far: 0.013323102363469608
+        year_built: 2.608667180000697e-05
+    T-Score:
+        b_ln_building_sqft: 62.14221212938504
+        building_type_id_is_84: 3.5647973281316987
+        land_area: 12.934226475577416
+        nodes_drv_drv_15min_retail_jobs: -0.22563877605224608
+        nodes_walk_ln_popden: 20.01298931486545
+        nodes_walk_max_medical_far: 9.487018440195431
+        year_built: -3.4003208576882935
+
+probability_mode: single_chooser
+
+log_likelihoods:
+    convergence: -11695.865902454854
+    'null': -13815.51055796495
+    ratio: 0.15342499624728478

--- a/configs/hlcm/no_interactions/hlcm2.yaml
+++ b/configs/hlcm/no_interactions/hlcm2.yaml
@@ -1,0 +1,71 @@
+name: MNLDiscreteChoiceModel
+
+model_type: discretechoice
+
+choosers_fit_filters: building_id>1
+
+choosers_predict_filters: income_quartile == 2
+
+alts_fit_filters: residential_units>0
+
+alts_predict_filters: null
+
+interaction_predict_filters: null
+
+choice_column: building_id
+
+sample_size: 100
+
+estimation_sample_size: 3000
+
+prediction_sample_size: null
+
+model_expression:
+- b_is_newerthan2010
+- nodes_walk_hhs_with_children
+- b_ln_building_sqft
+- b_ln_parcels_parcel_far
+- nodes_walk_sum_residential_units
+- nodes_drv_drv_10min_pop
+- nodes_walk_retail
+- nodes_walk_percent_mid_income
+
+fitted: true
+
+choice_mode: aggregate
+
+fit_parameters:
+    Coefficient:
+        b_is_newerthan2010: 0.5029426307730395
+        b_ln_building_sqft: 0.7780705150350777
+        b_ln_parcels_parcel_far: 0.3818291566181057
+        nodes_drv_drv_10min_pop: 0.050052274292020436
+        nodes_walk_hhs_with_children: -0.000276928749048701
+        nodes_walk_percent_mid_income: 3.0
+        nodes_walk_retail: 0.0007512246795854039
+        nodes_walk_sum_residential_units: 0.247003533299515
+    Std. Error:
+        b_is_newerthan2010: 0.1832107204824203
+        b_ln_building_sqft: 0.015538992912117341
+        b_ln_parcels_parcel_far: 0.1218246846923013
+        nodes_drv_drv_10min_pop: 0.012210933424719031
+        nodes_walk_hhs_with_children: 0.0003480269284302902
+        nodes_walk_percent_mid_income: 0.21468191489521196
+        nodes_walk_retail: 0.0002625356490908682
+        nodes_walk_sum_residential_units: 0.02145000156163417
+    T-Score:
+        b_is_newerthan2010: 2.745159395960667
+        b_ln_building_sqft: 50.072132694541395
+        b_ln_parcels_parcel_far: 3.134251137874977
+        nodes_drv_drv_10min_pop: 4.098972007389527
+        nodes_walk_hhs_with_children: -0.7957106948526538
+        nodes_walk_percent_mid_income: 13.974162665096056
+        nodes_walk_retail: 2.861419705045054
+        nodes_walk_sum_residential_units: 11.515315399384848
+
+probability_mode: single_chooser
+
+log_likelihoods:
+    convergence: -12575.025071829334
+    'null': -13815.51055796495
+    ratio: 0.08978933358495744

--- a/configs/hlcm/no_interactions/hlcm3.yaml
+++ b/configs/hlcm/no_interactions/hlcm3.yaml
@@ -1,0 +1,71 @@
+name: MNLDiscreteChoiceModel
+
+model_type: discretechoice
+
+choosers_fit_filters: building_id>1
+
+choosers_predict_filters: income_quartile == 3
+
+alts_fit_filters: residential_units>0
+
+alts_predict_filters: null
+
+interaction_predict_filters: null
+
+choice_column: building_id
+
+sample_size: 100
+
+estimation_sample_size: 3000
+
+prediction_sample_size: null
+
+model_expression:
+- b_is_newerthan2010
+- b_ln_building_sqft
+- nodes_walk_medical
+- nodes_walk_population
+- nodes_drv_drv_15min_retail_jobs
+- nodes_walk_ave_lot_sqft
+- crime08
+- sqft_price_res
+
+fitted: true
+
+choice_mode: aggregate
+
+fit_parameters:
+    Coefficient:
+        b_is_newerthan2010: 0.5047942105816854
+        b_ln_building_sqft: 0.7148231545661907
+        crime08: -0.006598245548189589
+        nodes_drv_drv_15min_retail_jobs: 0.005696791688018663
+        nodes_walk_ave_lot_sqft: 0.09424658193678591
+        nodes_walk_medical: 0.001131624382105395
+        nodes_walk_population: 0.0003437910565283324
+        sqft_price_res: -0.0017009025822761115
+    Std. Error:
+        b_is_newerthan2010: 0.17890572087324053
+        b_ln_building_sqft: 0.017329182362947355
+        crime08: 0.0009831886224685262
+        nodes_drv_drv_15min_retail_jobs: 0.01553460700038075
+        nodes_walk_ave_lot_sqft: 0.025410972771059817
+        nodes_walk_medical: 0.00032895334132241146
+        nodes_walk_population: 6.988162155512183e-05
+        sqft_price_res: 0.00022378509925567784
+    T-Score:
+        b_is_newerthan2010: 2.821565504544964
+        b_ln_building_sqft: 41.24967581243766
+        crime08: -6.711067843343368
+        nodes_drv_drv_15min_retail_jobs: 0.366716176848184
+        nodes_walk_ave_lot_sqft: 3.7088931142424406
+        nodes_walk_medical: 3.4400756580133813
+        nodes_walk_population: 4.919620479286587
+        sqft_price_res: -7.600606957002104
+
+probability_mode: single_chooser
+
+log_likelihoods:
+    convergence: -13107.316572966209
+    'null': -13815.51055796495
+    ratio: 0.05126078996700212

--- a/configs/hlcm/no_interactions/hlcm4.yaml
+++ b/configs/hlcm/no_interactions/hlcm4.yaml
@@ -1,0 +1,75 @@
+name: MNLDiscreteChoiceModel
+
+model_type: discretechoice
+
+choosers_fit_filters: building_id>1
+
+choosers_predict_filters: income_quartile == 4
+
+alts_fit_filters: residential_units>0
+
+alts_predict_filters: null
+
+interaction_predict_filters: null
+
+choice_column: building_id
+
+sample_size: 100
+
+estimation_sample_size: 3000
+
+prediction_sample_size: null
+
+model_expression:
+- b_is_pre_1945
+- crime_other_rate
+- b_ln_building_sqft
+- building_type_id_is_81
+- nodes_walk_industrial
+- stories
+- b_ln_land_area
+- nodes_drv_drv_30min_jobs
+- nodes_walk_percent_hh_with_children
+
+fitted: true
+
+choice_mode: aggregate
+
+fit_parameters:
+    Coefficient:
+        b_is_pre_1945: -0.19605741833321147
+        b_ln_building_sqft: 0.11340863542032992
+        b_ln_land_area: 0.8762524354952299
+        building_type_id_is_81: 0.17416147401117552
+        crime_other_rate: -7.397352297869432e-05
+        nodes_drv_drv_30min_jobs: 0.025294366105569285
+        nodes_walk_industrial: -0.0016574719661584447
+        nodes_walk_percent_hh_with_children: 0.960476479544499
+        stories: 0.15183924472105126
+    Std. Error:
+        b_is_pre_1945: 0.04570214794678114
+        b_ln_building_sqft: 0.02159646112694965
+        b_ln_land_area: 0.02615698550268842
+        building_type_id_is_81: 0.056942550640887574
+        crime_other_rate: 7.126403455194634e-06
+        nodes_drv_drv_30min_jobs: 0.012460598446624706
+        nodes_walk_industrial: 0.0008969078779806792
+        nodes_walk_percent_hh_with_children: 0.1952513458758694
+        stories: 0.018552794814002932
+    T-Score:
+        b_is_pre_1945: -4.289895051793075
+        b_ln_building_sqft: 5.251260137190268
+        b_ln_land_area: 33.49974848612309
+        building_type_id_is_81: 3.058547115487288
+        crime_other_rate: -10.380204186274769
+        nodes_drv_drv_30min_jobs: 2.0299479366033943
+        nodes_walk_industrial: -1.8479846223339218
+        nodes_walk_percent_hh_with_children: 4.919179815309032
+        stories: 8.184170969564589
+
+probability_mode: single_chooser
+
+log_likelihoods:
+    convergence: -13025.336711511776
+    'null': -13815.51055796495
+    ratio: 0.057194690209810606

--- a/configs/hlcm_constraints.yaml
+++ b/configs/hlcm_constraints.yaml
@@ -1,6 +1,38 @@
+- name: income_interactions
+  sign: positive
+  variables: ['ln_income:sqft_price_res', 'ln_income:b_is_pre_1945', 
+              'ln_income:building_type_id_is_81', 'ln_income:b_is_newerthan2010', 'ln_income:nodes_walk_ave_income',
+              'ln_income:parcels_acres', 'ln_income:sqft_per_unit', 'ln_income:nodes_walk_ln_popden']
+
+- name: hhsize_interactions
+  sign: positive
+  variables: ['persons:nodes_walk_ln_popden', 'persons:sqft_per_unit', 'hhsize_gt_2:building_type_id_is_81']
+
+- name: children_interactions
+  sign: positive
+  variables: ['has_children:building_type_id_is_81', 'has_children:sqft_per_unit',
+              'has_children:nodes_walk_percent_hh_with_children', 'has_children:nodes_drv_elem_school_perf']
+
+- name: young_interactions
+  sign: positive
+  variables: ['is_young:zones_empden', 'is_young:nodes_walk_retail_jobs']
+
+- name: worker_interactions
+  sign: positive
+  variables: ['has_workers:nodes_drv_drv_45min_jobs', 'has_workers:zones_a_ln_emp_50min_transit']
+
+- name: race_clustering
+  sign: positive
+  variables: ['is_race1:nodes_walk_percent_race1', 'is_race2:nodes_walk_percent_race2',
+              'is_race3:nodes_walk_percent_race3', 'is_race4:nodes_walk_percent_race4']
+
+- name: price_attempt1
+  sign: negative
+  variables: [sqft_price_res]
+
 - name: building_space
   sign: positive
-  variables: [b_ln_building_sqft,building_sqft,residential_units,sqft_per_unit, nodes_walk_ave_unit_sqft, parcels_ave_unit_size]
+  variables: [sqft_per_unit, nodes_walk_ave_unit_sqft, parcels_ave_unit_size]
 
 - name: size_vars
   sign: positive
@@ -12,12 +44,8 @@
   variables: [crime_ucr_rate, crime_other_rate, crime08]
 
 - name: building_age
-  sign: ''
-  variables: [b_is_newerthan2010,b_is_pre_1945,building_age,year_built]
-
-- name: price_attempt1
-  sign: negative
-  variables: [sqft_price_res]
+  sign: positive
+  variables: [b_is_newerthan2010, b_is_pre_1945, year_built]
 
 - name: land_area
   sign: positive
@@ -32,6 +60,10 @@
 - name: employment_access_transit
   sign: positive
   variables: [zones_transit_jobs_50min, zones_a_ln_emp_50min_transit]
+
+- name: price_attempt2
+  sign: negative
+  variables: [sqft_price_res]
 
 - name: other_access
   sign: ''
@@ -52,10 +84,6 @@
 - name: negative_structure
   sign: negative
   variables: [building_type_id_is_82,building_type_id_is_83,building_type_id_is_84]
-
-- name: price_attempt2
-  sign: negative
-  variables: [sqft_price_res]
 
 - name: income_clustering
   sign: positive

--- a/configs/hlcm_constraints.yaml
+++ b/configs/hlcm_constraints.yaml
@@ -1,8 +1,7 @@
 - name: income_interactions
   sign: positive
-  variables: ['ln_income:sqft_price_res', 'ln_income:b_is_pre_1945', 
-              'ln_income:building_type_id_is_81', 'ln_income:b_is_newerthan2010', 'ln_income:nodes_walk_ave_income',
-              'ln_income:parcels_acres', 'ln_income:sqft_per_unit', 'ln_income:nodes_walk_ln_popden']
+  variables: ['ln_income:b_is_pre_1945', 'ln_income:building_type_id_is_81', 'ln_income:b_is_newerthan2010', 
+              'ln_income:nodes_walk_ave_income','ln_income:parcels_acres', 'ln_income:sqft_per_unit', 'ln_income:nodes_walk_ln_popden']
 
 - name: hhsize_interactions
   sign: positive
@@ -28,7 +27,7 @@
 
 - name: price_attempt1
   sign: negative
-  variables: [sqft_price_res]
+  variables: [sqft_price_res, ln_income:sqft_price_res]
 
 - name: building_space
   sign: positive
@@ -63,7 +62,7 @@
 
 - name: price_attempt2
   sign: negative
-  variables: [sqft_price_res]
+  variables: [sqft_price_res, ln_income:sqft_price_res]
 
 - name: other_access
   sign: ''
@@ -115,4 +114,4 @@
 
 - name: price_attempt3
   sign: negative
-  variables: [sqft_price_res]
+  variables: [sqft_price_res, ln_income:sqft_price_res]

--- a/variables/variables_demographic.py
+++ b/variables/variables_demographic.py
@@ -1,4 +1,5 @@
 import orca
+import numpy as np
 import pandas as pd
 from urbansim.utils import misc
 
@@ -55,6 +56,81 @@ def nodeid_walk(households, buildings):
 @orca.column('households', cache=True, cache_scope='iteration')
 def nodeid_drv(households, buildings):
     return misc.reindex(buildings.nodeid_drv, households.building_id)
+
+
+@orca.column('households', 'ln_income', cache=True, cache_scope='iteration')
+def ln_income(households):
+    return np.log1p(households.income)
+
+
+@orca.column('households', 'low_income', cache=True, cache_scope='iteration')
+def low_income(households):
+    return (households.income_quartile == 1).astype('int32')
+
+
+@orca.column('households', 'mid_income', cache=True, cache_scope='iteration')
+def mid_income(households):
+    return (households.income_quartile.isin([2, 3])).astype('int32')
+
+
+@orca.column('households', 'high_income', cache=True, cache_scope='iteration')
+def high_income(households):
+    return (households.income_quartile == 4).astype('int32')
+
+
+@orca.column('households', 'hhsize_gt_2', cache=True, cache_scope='iteration')
+def hhsize_gt_2(households):
+    return (households.persons > 2).astype('int32')
+
+
+@orca.column('households', 'hhsize_is_1', cache=True, cache_scope='iteration')
+def hhsize_is_1(households):
+    return (households.persons == 1).astype('int32')
+
+
+@orca.column('households', 'has_children', cache=True, cache_scope='iteration')
+def has_children(households):
+    return (households.children > 0).astype('int32')
+
+
+@orca.column('households', 'is_young', cache=True, cache_scope='iteration')
+def has_children(households):
+    return (households.age_of_head < 35).astype('int32')
+
+
+@orca.column('households', 'is_race1', cache=True, cache_scope='iteration')
+def is_race1(households):
+    return (households.race_id == 1).astype('int32')
+
+
+@orca.column('households', 'is_race2', cache=True, cache_scope='iteration')
+def is_race2(households):
+    return (households.race_id == 2).astype('int32')
+
+
+@orca.column('households', 'is_race3', cache=True, cache_scope='iteration')
+def is_race3(households):
+    return (households.race_id == 3).astype('int32')
+
+
+@orca.column('households', 'is_race4', cache=True, cache_scope='iteration')
+def is_race4(households):
+    return (households.race_id == 4).astype('int32')
+
+
+@orca.column('households', 'has_workers', cache=True, cache_scope='iteration')
+def has_workers(households):
+    return (households.workers > 0).astype('int32')
+
+
+@orca.column('households', 'workers_gt_cars', cache=True, cache_scope='iteration')
+def workers_gt_cars(households):
+    return (households.workers > households.cars).astype('int32')
+
+
+@orca.column('households', 'workers_lte_cars', cache=True, cache_scope='iteration')
+def workers_lte_cars(households):
+    return (households.workers <= households.cars).astype('int32')
 
 
 #####################


### PR DESCRIPTION
Changes:
* Additional household variables.
* Updated HLCM specifications with interaction variables.
* Lottery choice to unit_choices.

(The `unit_choice` simulation strategy for location choice models only properly simulated an MNLDiscreteChoiceModel that has probability_mode of `single_chooser` and choice_mode of `aggregate`.   But once we introduce interaction variables into a model specification, the model should have a probability_mode of `full_product` and a choice_mode of `individual` so as to take advantage of variation in attribute values across choosers.  If running unit_choices with a model that uses `full_product`/`individual`, there will be duplicate choices (agents may choose a unit alternative multiple times).  This PR introduces lottery choices functionality to unit_choices so that each unit alternatives is selected at most a single time.  Lottery choices means that in the case of duplicate choices, only one lucky chooser gets the alternative, and the remaining choosers of that alternative must re-choose (do this iteratively until all choices are unique and capacity is respected).)