### PR TITLE
Simulate REPM configs generated by autospec

### DIFF
--- a/REPM Estimation.ipynb
+++ b/REPM Estimation.ipynb
@@ -1,0 +1,230 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from urbansim.models.regression import RegressionModel\n",
+    "\n",
+    "import os\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "import orca\n",
+    "from urbansim.utils import misc\n",
+    "\n",
+    "import dataset\n",
+    "import variables\n",
+    "import models\n",
+    "import utils\n",
+    "\n",
+    "orca.run([\"build_networks\"])\n",
+    "orca.run([\"neighborhood_vars\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## REPM Estimation Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def estimate_repm(yaml_config):\n",
+    "    model = RegressionModel.from_yaml(str_or_buffer=misc.config(yaml_config))\n",
+    "\n",
+    "    b = orca.get_table('buildings').to_frame(model.columns_used()).fillna(0)\n",
+    "\n",
+    "    print model.fit(b)\n",
+    "\n",
+    "    return model.fit_parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## REPM Configs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "repm_configs = ['repm/nonres_repm12531.yaml',\n",
+    "                 'repm/res_repm16182.yaml',\n",
+    "                 'repm/res_repm384.yaml',\n",
+    "                 'repm/nonres_repm321.yaml',\n",
+    "                 'repm/nonres_repm11523.yaml',\n",
+    "                 'repm/nonres_repm371.yaml',\n",
+    "                 'repm/res_repm382.yaml',\n",
+    "                 'repm/nonres_repm9931.yaml',\n",
+    "                 'repm/nonres_repm9926.yaml',\n",
+    "                 'repm/res_repm12582.yaml',\n",
+    "                 'repm/res_repm16184.yaml',\n",
+    "                 'repm/nonres_repm24.yaml',\n",
+    "                 'repm/res_repm583.yaml',\n",
+    "                 'repm/nonres_repm9321.yaml',\n",
+    "                 'repm/nonres_repm32.yaml',\n",
+    "                 'repm/nonres_repm9922.yaml',\n",
+    "                 'repm/nonres_repm9341.yaml',\n",
+    "                 'repm/nonres_repm16122.yaml',\n",
+    "                 'repm/res_repm9981.yaml',\n",
+    "                 'repm/nonres_repm16131.yaml',\n",
+    "                 'repm/nonres_repm9323.yaml',\n",
+    "                 'repm/nonres_repm541.yaml',\n",
+    "                 'repm/nonres_repm14771.yaml',\n",
+    "                 'repm/nonres_repm61.yaml',\n",
+    "                 'repm/nonres_repm333.yaml',\n",
+    "                 'repm/nonres_repm531.yaml',\n",
+    "                 'repm/nonres_repm551.yaml',\n",
+    "                 'repm/nonres_repm16151.yaml',\n",
+    "                 'repm/res_repm383.yaml',\n",
+    "                 'repm/res_repm16183.yaml',\n",
+    "                 'repm/nonres_repm9325.yaml',\n",
+    "                 'repm/nonres_repm42.yaml',\n",
+    "                 'repm/nonres_repm16126.yaml',\n",
+    "                 'repm/nonres_repm12533.yaml',\n",
+    "                 'repm/nonres_repm12522.yaml',\n",
+    "                 'repm/nonres_repm16125.yaml',\n",
+    "                 'repm/nonres_repm11521.yaml',\n",
+    "                 'repm/nonres_repm9331.yaml',\n",
+    "                 'repm/nonres_repm43.yaml',\n",
+    "                 'repm/res_repm9983.yaml',\n",
+    "                 'repm/nonres_repm325.yaml',\n",
+    "                 'repm/nonres_repm9941.yaml',\n",
+    "                 'repm/nonres_repm323.yaml',\n",
+    "                 'repm/nonres_repm523.yaml',\n",
+    "                 'repm/res_repm582.yaml',\n",
+    "                 'repm/nonres_repm14721.yaml',\n",
+    "                 'repm/nonres_repm52.yaml',\n",
+    "                 'repm/nonres_repm12525.yaml',\n",
+    "                 'repm/nonres_repm9951.yaml',\n",
+    "                 'repm/nonres_repm14725.yaml',\n",
+    "                 'repm/nonres_repm521.yaml',\n",
+    "                 'repm/res_repm14782.yaml',\n",
+    "                 'repm/nonres_repm14723.yaml',\n",
+    "                 'repm/nonres_repm12521.yaml',\n",
+    "                 'repm/nonres_repm14751.yaml',\n",
+    "                 'repm/res_repm14781.yaml',\n",
+    "                 'repm/res_repm12584.yaml',\n",
+    "                 'repm/nonres_repm12523.yaml',\n",
+    "                 'repm/nonres_repm16171.yaml',\n",
+    "                 'repm/nonres_repm12526.yaml',\n",
+    "                 'repm/nonres_repm351.yaml',\n",
+    "                 'repm/res_repm11583.yaml',\n",
+    "                 'repm/nonres_repm16123.yaml',\n",
+    "                 'repm/res_repm11581.yaml',\n",
+    "                 'repm/nonres_repm12541.yaml',\n",
+    "                 'repm/nonres_repm9333.yaml',\n",
+    "                 'repm/nonres_repm62.yaml',\n",
+    "                 'repm/nonres_repm331.yaml',\n",
+    "                 'repm/nonres_repm53.yaml',\n",
+    "                 'repm/nonres_repm322.yaml',\n",
+    "                 'repm/res_repm12581.yaml',\n",
+    "                 'repm/nonres_repm9322.yaml',\n",
+    "                 'repm/nonres_repm326.yaml',\n",
+    "                 'repm/nonres_repm525.yaml',\n",
+    "                 'repm/res_repm9383.yaml',\n",
+    "                 'repm/nonres_repm14726.yaml',\n",
+    "                 'repm/res_repm11584.yaml',\n",
+    "                 'repm/res_repm9384.yaml',\n",
+    "                 'repm/res_repm16181.yaml',\n",
+    "                 'repm/res_repm9982.yaml',\n",
+    "                 'repm/nonres_repm12571.yaml',\n",
+    "                 'repm/res_repm9984.yaml',\n",
+    "                 'repm/res_repm14784.yaml',\n",
+    "                 'repm/nonres_repm11522.yaml',\n",
+    "                 'repm/nonres_repm9925.yaml',\n",
+    "                 'repm/nonres_repm9351.yaml',\n",
+    "                 'repm/nonres_repm11526.yaml',\n",
+    "                 'repm/nonres_repm9921.yaml',\n",
+    "                 'repm/nonres_repm14731.yaml',\n",
+    "                 'repm/nonres_repm14722.yaml',\n",
+    "                 'repm/nonres_repm522.yaml',\n",
+    "                 'repm/res_repm9382.yaml',\n",
+    "                 'repm/nonres_repm533.yaml',\n",
+    "                 'repm/nonres_repm9971.yaml',\n",
+    "                 'repm/nonres_repm11525.yaml',\n",
+    "                 'repm/nonres_repm526.yaml',\n",
+    "                 'repm/nonres_repm9923.yaml',\n",
+    "                 'repm/nonres_repm16133.yaml',\n",
+    "                 'repm/nonres_repm11531.yaml',\n",
+    "                 'repm/nonres_repm11551.yaml',\n",
+    "                 'repm/res_repm9381.yaml',\n",
+    "                 'repm/nonres_repm9326.yaml',\n",
+    "                 'repm/nonres_repm11571.yaml',\n",
+    "                 'repm/nonres_repm16141.yaml',\n",
+    "                 'repm/res_repm12583.yaml',\n",
+    "                 'repm/nonres_repm11541.yaml',\n",
+    "                 'repm/res_repm581.yaml',\n",
+    "                 'repm/res_repm11582.yaml',\n",
+    "                 'repm/nonres_repm9933.yaml',\n",
+    "                 'repm/res_repm14783.yaml',\n",
+    "                 'repm/nonres_repm16121.yaml',\n",
+    "                 'repm/nonres_repm9371.yaml',\n",
+    "                 'repm/nonres_repm11533.yaml',\n",
+    "                 'repm/nonres_repm14733.yaml',\n",
+    "                 'repm/nonres_repm14741.yaml',\n",
+    "                 'repm/nonres_repm12551.yaml',\n",
+    "                 'repm/nonres_repm341.yaml',\n",
+    "                 'repm/res_repm381.yaml']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Estimate a particular REPM submodel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "estimate_repm('repm/nonres_repm24.yaml')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Simulation.py
+++ b/Simulation.py
@@ -10,11 +10,9 @@ import output_indicators
 data_out = utils.get_run_filename()
 
 orca.run(['build_networks',
-          "neighborhood_vars",
-          "nrh_simulate",  # non-residential rent hedonic
-          "rsh_simulate",  # residential sales hedonic
-          "increase_property_values",  # Hack to make more feasibility
-          ])
+          "neighborhood_vars"] +
+          orca.get_injectable('repm_step_names') + # In place of ['nrh_simulate', 'rsh_simulate']
+          ["increase_property_values"])  # Hack to make more feasibility
 
 orca.run([
     "neighborhood_vars",
@@ -29,9 +27,10 @@ orca.run([
     "residential_developer",
     "non_residential_developer",
     "nrh_simulate",
-    "rsh_simulate",
-    "increase_property_values",  # Hack to make more feasibility
-    ] + orca.get_injectable('hlcm_step_names') +
+    "rsh_simulate"] + 
+    orca.get_injectable('repm_step_names') + # In place of ['nrh_simulate', 'rsh_simulate']
+    ["increase_property_values"] +  # Hack to make more feasibility
+    orca.get_injectable('hlcm_step_names') +
     ["elcm_simulate",
     "government_jobs_scaling_model",
     "refiner",

--- a/Simulation_no_scaling.py
+++ b/Simulation_no_scaling.py
@@ -11,8 +11,8 @@ data_out = utils.get_run_filename()
 
 orca.run(['build_networks',
           "neighborhood_vars"] +
-          orca.get_injectable('repm_step_names') + # In place of ['nrh_simulate', 'rsh_simulate']
-          ["increase_property_values"])  # Hack to make more feasibility
+          orca.get_injectable('repm_step_names')) # + # In place of ['nrh_simulate', 'rsh_simulate']
+          #["increase_property_values"])  # Hack to make more feasibility
 
 orca.run([
     "neighborhood_vars",
@@ -27,7 +27,7 @@ orca.run([
     "residential_developer",
     "non_residential_developer"] +
     orca.get_injectable('repm_step_names') + # In place of ['nrh_simulate', 'rsh_simulate']
-    ["increase_property_values"] +  # Hack to make more feasibility
+    #["increase_property_values"] +  # Hack to make more feasibility
     orca.get_injectable('hlcm_step_names') +
     ["elcm_simulate",
     "government_jobs_scaling_model",

--- a/models.py
+++ b/models.py
@@ -77,7 +77,7 @@ def nrh_simulate(buildings, nodes_walk):
 
 def make_repm_func(model_name, yaml_file, dep_var):
     """
-    Generator function for block REPMs.
+    Generator function for single-model REPMs.
     """
     @orca.step(model_name)
     def func():

--- a/utils.py
+++ b/utils.py
@@ -94,6 +94,8 @@ def to_frame(tables, cfg, additional_columns=[]):
                                tables=tables, columns=columns)
     else:
         df = tables[0].to_frame(columns)
+    df = df.replace([np.inf, -np.inf], 0)
+    df = df.fillna(0)
     df = deal_with_nas(df)
     return df
 

--- a/utils.py
+++ b/utils.py
@@ -94,8 +94,6 @@ def to_frame(tables, cfg, additional_columns=[]):
                                tables=tables, columns=columns)
     else:
         df = tables[0].to_frame(columns)
-    df = df.replace([np.inf, -np.inf], 0)
-    df = df.fillna(0)
     df = deal_with_nas(df)
     return df
 
@@ -125,7 +123,8 @@ def hedonic_simulate(cfg, tbl, nodes, out_fname):
     if price_or_rent.replace([np.inf, -np.inf], np.nan).isnull().sum() > 0:
         print "Hedonic output %d nas or inf (out of %d) in column %s" % \
               (price_or_rent.replace([np.inf, -np.inf], np.nan).isnull().sum(), len(price_or_rent), out_fname)
-        price_or_rent[price_or_rent > 1000] = 1000
+    price_or_rent[price_or_rent > 700] = 700
+    price_or_rent[price_or_rent < 1] = 1
     tbl.update_col_from_series(out_fname, price_or_rent)
 
 


### PR DESCRIPTION
This PR facilitates simulation of autospec-generated real estate price model (REPM) configuration files.   This is the code counterpart to #10 