### PR TITLE
Probability-based building type callback

### DIFF
--- a/models.py
+++ b/models.py
@@ -654,7 +654,6 @@ def run_developer(target_units, lid, forms, buildings, supply_fname,
     from developer import develop
     print 'processing large area id:', lid
     cfg = misc.config(cfg)
-    b = buildings.to_frame([supply_fname, "large_area_id", "building_type_id"])
     dev = develop.Developer.from_yaml(orca.get_table('feasibility_' + str(lid)).to_frame(), forms,
                                       target_units, parcel_size,
                                       ave_unit_size, current_units,
@@ -669,8 +668,7 @@ def run_developer(target_units, lid, forms, buildings, supply_fname,
     if new_buildings is None or len(new_buildings) == 0:
         return
 
-    register_btype_distributions(b)
-
+    register_btype_distributions(buildings.to_frame(["building_type_id"]))
     parcel_utils.add_buildings(dev.feasibility,
                                buildings,
                                new_buildings,

--- a/models.py
+++ b/models.py
@@ -588,6 +588,27 @@ def random_type(row):
     return random.choice(form_to_btype[form])
 
 
+def probable_type(row):
+    form = row['form']
+    form_to_btype = orca.get_injectable("form_to_btype")
+    btypes = form_to_btype[form]
+
+    buildings = orca.get_table('buildings').to_frame([''])
+
+    return random.choice(form_to_btype[form])
+
+
+def register_btype_distributions(buildings):
+    """
+
+    """
+    form_to_btype = orca.get_injectable("form_to_btype")
+    form_btype_dists = {}
+    for form in form_to_btype.keys():
+        bldgs = buildings.loc[buildings.building_type_id
+                                       .isin(form_to_btype[form])]
+
+
 def run_developer(lid, forms, agents, buildings, supply_fname,
                   parcel_size, ave_unit_size, current_units, cfg,
                   target_vacancy=0.1,
@@ -602,7 +623,7 @@ def run_developer(lid, forms, agents, buildings, supply_fname,
     print 'processing large area id:', lid
     cfg = misc.config(cfg)
 
-    b = buildings.to_frame([supply_fname, "large_area_id"])
+    b = buildings.to_frame([supply_fname, "large_area_id", "building_type_id"])
     target_units = parcel_utils.compute_units_to_build((agents.large_area_id == lid).sum(),
                                                        b[b.large_area_id == lid][supply_fname].sum(),
                                                        target_vacancy)

--- a/models.py
+++ b/models.py
@@ -617,7 +617,8 @@ def register_btype_distributions(buildings):
     function registers a dictionary where keys are forms, and values are
     dictionaries of building types. In each sub-dictionary, the keys are
     building type IDs, and values are probabilities. These probabilities are
-    generated from region-wide distributions of building types for each form.
+    generated from distributions of building types for each form in each
+    large area.
 
     Parameters
     ----------

--- a/models.py
+++ b/models.py
@@ -668,7 +668,6 @@ def run_developer(target_units, lid, forms, buildings, supply_fname,
     if new_buildings is None or len(new_buildings) == 0:
         return
 
-    register_btype_distributions(buildings.to_frame(["building_type_id"]))
     parcel_utils.add_buildings(dev.feasibility,
                                buildings,
                                new_buildings,
@@ -682,13 +681,14 @@ def run_developer(target_units, lid, forms, buildings, supply_fname,
 def residential_developer(households, parcels, target_vacancies):
     target_vacancies = target_vacancies.to_frame()
     target_vacancies = target_vacancies[target_vacancies.year == orca.get_injectable('year')]
-    orig_buildings = orca.get_table('buildings').to_frame(["residential_units", "large_area_id"])
+    orig_buildings = orca.get_table('buildings').to_frame(["residential_units", "large_area_id", "building_type_id"])
     for lid, _ in parcels.large_area_id.to_frame().groupby('large_area_id'):
         la_orig_buildings = orig_buildings[orig_buildings.large_area_id == lid]
         target_vacancy = float(target_vacancies[target_vacancies.large_area_id == lid].res_target_vacancy_rate)
         target_units = parcel_utils.compute_units_to_build((households.large_area_id == lid).sum(),
                                                            la_orig_buildings.residential_units.sum(),
                                                            target_vacancy)
+        register_btype_distributions(la_orig_buildings)
         run_developer(
             target_units,
             lid,
@@ -706,7 +706,7 @@ def residential_developer(households, parcels, target_vacancies):
 def non_residential_developer(jobs, parcels, target_vacancies):
     target_vacancies = target_vacancies.to_frame()
     target_vacancies = target_vacancies[target_vacancies.year == orca.get_injectable('year')]
-    orig_buildings = orca.get_table('buildings').to_frame(["job_spaces", "large_area_id"])
+    orig_buildings = orca.get_table('buildings').to_frame(["job_spaces", "large_area_id", "building_type_id"])
     for lid, _ in parcels.large_area_id.to_frame().groupby('large_area_id'):
         la_orig_buildings = orig_buildings[orig_buildings.large_area_id == lid]
         target_vacancy = float(target_vacancies[target_vacancies.large_area_id == lid].non_res_target_vacancy_rate)
@@ -714,6 +714,7 @@ def non_residential_developer(jobs, parcels, target_vacancies):
         target_units = parcel_utils.compute_units_to_build(num_jobs,
                                                            la_orig_buildings.job_spaces.sum(),
                                                            target_vacancy)
+        register_btype_distributions(la_orig_buildings)
         run_developer(
             target_units,
             lid,

--- a/test_btype.py
+++ b/test_btype.py
@@ -1,7 +1,0 @@
-import models
-import dataset
-import orca
-
-f = orca.get_injectable('form_to_btype')
-
-print(f)

--- a/test_btype.py
+++ b/test_btype.py
@@ -1,0 +1,7 @@
+import models
+import dataset
+import orca
+
+f = orca.get_injectable('form_to_btype')
+
+print(f)


### PR DESCRIPTION
This PR implements an alternative callback function for the `form_to_btype_callback` parameter in the urbansim_parcels `add_buildings` function. This replaces the `random_type` callback that was used previously. 

Where `random_type` selected a truly random allowed building type, the new function `probable_type` assigns a building type to new buildings based on probabilities for each type. The probabilities reflect the proportions of building types for each form in each large area in each simulation year. The `register_btype_distributions` registers a dictionary as an Orca injectable with the proportions mentioned above.