### PR TITLE
Format HLCM model expressions as patsy string

### DIFF
--- a/configs/hlcm/large_area_income_quartile/hlcm100003.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm100003.yaml
@@ -20,17 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- zones_logsum_job_high_income
-- walk_nearest_healthcenter
-- has_children:nodes_walk_percent_hh_with_children
-- popden
-- is_race4:nodes_walk_percent_race4
-- nodes_walk_sum_residential_units
-- ln_income:sqft_price_res
-- is_young:nodes_walk_retail_jobs
-- ln_income:nodes_walk_ln_popden
-- zones_transit_jobs_50min
+model_expression: zones_logsum_job_high_income + walk_nearest_healthcenter + has_children:nodes_walk_percent_hh_with_children
+    + popden + is_race4:nodes_walk_percent_race4 + nodes_walk_sum_residential_units
+    + ln_income:sqft_price_res + is_young:nodes_walk_retail_jobs + ln_income:nodes_walk_ln_popden
+    + zones_transit_jobs_50min
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm100005.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm100005.yaml
@@ -20,17 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- zones_logsum_job_high_income
-- residential_units
-- has_children:nodes_walk_percent_hh_with_children
-- has_workers:zones_a_ln_emp_50min_transit
-- is_race1:nodes_walk_percent_race1
-- persons:nodes_walk_ln_popden
-- building_age_le_10
-- is_young:nodes_walk_retail_jobs
-- ln_income:nodes_walk_ln_popden
-- nodes_drv_drv_30min_jobs
+model_expression: zones_logsum_job_high_income + residential_units + has_children:nodes_walk_percent_hh_with_children
+    + has_workers:zones_a_ln_emp_50min_transit + is_race1:nodes_walk_percent_race1
+    + persons:nodes_walk_ln_popden + building_age_le_10 + is_young:nodes_walk_retail_jobs
+    + ln_income:nodes_walk_ln_popden + nodes_drv_drv_30min_jobs
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm100093.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm100093.yaml
@@ -20,19 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- zones_logsum_job_high_income
-- residential_units
-- has_children:nodes_walk_percent_hh_with_children
-- building_age_gt_70
-- nodes_walk_ave_nonres_sqft_price
-- building_type_id_is_83
-- nodes_walk_percent_low_income
-- b_total_jobs
-- is_young:zones_empden
-- ln_income:nodes_walk_ln_popden
-- b_ln_parcel_sqft
-- zones_a_ln_retail_emp_15min_drive_alone
+model_expression: zones_logsum_job_high_income + residential_units + has_children:nodes_walk_percent_hh_with_children
+    + building_age_gt_70 + nodes_walk_ave_nonres_sqft_price + building_type_id_is_83
+    + nodes_walk_percent_low_income + b_total_jobs + is_young:zones_empden + ln_income:nodes_walk_ln_popden
+    + b_ln_parcel_sqft + zones_a_ln_retail_emp_15min_drive_alone
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm100099.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm100099.yaml
@@ -20,18 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- residential_units
-- building_age_gt_70
-- nodes_walk_retail_jobs
-- nodes_walk_race_1_hhs
-- vacant_residential_units
-- persons:nodes_walk_ln_popden
-- nodes_walk_ave_lot_sqft
-- is_young:zones_empden
-- is_race2:nodes_walk_percent_race2
-- ln_income:nodes_walk_ln_popden
-- zones_a_ln_retail_emp_15min_drive_alone
+model_expression: residential_units + building_age_gt_70 + nodes_walk_retail_jobs
+    + nodes_walk_race_1_hhs + vacant_residential_units + persons:nodes_walk_ln_popden
+    + nodes_walk_ave_lot_sqft + is_young:zones_empden + is_race2:nodes_walk_percent_race2
+    + ln_income:nodes_walk_ln_popden + zones_a_ln_retail_emp_15min_drive_alone
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm100115.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm100115.yaml
@@ -20,14 +20,9 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- residential_units
-- b_ln_parcels_parcel_far
-- nodes_drv_drv_15min_retail_jobs
-- persons:nodes_walk_ln_popden
-- is_race2:nodes_walk_percent_race2
-- has_workers:nodes_drv_drv_45min_jobs
-- ln_income:nodes_walk_ln_popden
+model_expression: residential_units + b_ln_parcels_parcel_far + nodes_drv_drv_15min_retail_jobs
+    + persons:nodes_walk_ln_popden + is_race2:nodes_walk_percent_race2 + has_workers:nodes_drv_drv_45min_jobs
+    + ln_income:nodes_walk_ln_popden
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm100125.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm100125.yaml
@@ -20,18 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- has_children:nodes_drv_elem_school_perf
-- nodes_walk_population
-- residential_units
-- nodes_walk_midinc_hhs
-- b_ln_parcel_sqft
-- nodes_drv_drv_45min_jobs
-- persons:nodes_walk_ln_popden
-- zones_a_ln_emp_50min_transit
-- is_young:zones_empden
-- is_race2:nodes_walk_percent_race2
-- ln_income:nodes_walk_ln_popden
+model_expression: has_children:nodes_drv_elem_school_perf + nodes_walk_population
+    + residential_units + nodes_walk_midinc_hhs + b_ln_parcel_sqft + nodes_drv_drv_45min_jobs
+    + persons:nodes_walk_ln_popden + zones_a_ln_emp_50min_transit + is_young:zones_empden
+    + is_race2:nodes_walk_percent_race2 + ln_income:nodes_walk_ln_popden
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm100147.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm100147.yaml
@@ -20,18 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- residential_units
-- b_is_pre_1945
-- has_children:nodes_walk_percent_hh_with_children
-- has_workers:zones_a_ln_emp_50min_transit
-- b_ln_parcel_sqft
-- nodes_walk_lowinc_hhs
-- persons:nodes_walk_ln_popden
-- is_race2:nodes_walk_percent_race2
-- is_young:nodes_walk_retail_jobs
-- ln_income:nodes_walk_ln_popden
-- zones_a_ln_retail_emp_15min_drive_alone
+model_expression: residential_units + b_is_pre_1945 + has_children:nodes_walk_percent_hh_with_children
+    + has_workers:zones_a_ln_emp_50min_transit + b_ln_parcel_sqft + nodes_walk_lowinc_hhs
+    + persons:nodes_walk_ln_popden + is_race2:nodes_walk_percent_race2 + is_young:nodes_walk_retail_jobs
+    + ln_income:nodes_walk_ln_popden + zones_a_ln_retail_emp_15min_drive_alone
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm100161.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm100161.yaml
@@ -20,18 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- residential_units
-- has_children:nodes_walk_percent_hh_with_children
-- zones_employment
-- has_workers:zones_a_ln_emp_50min_transit
-- nodes_drv_drv_60min_jobs
-- persons:nodes_walk_ln_popden
-- nodes_walk_ave_lot_sqft
-- is_young:zones_empden
-- is_race2:nodes_walk_percent_race2
-- ln_income:nodes_walk_ln_popden
-- zones_transit_jobs_30min
+model_expression: residential_units + has_children:nodes_walk_percent_hh_with_children
+    + zones_employment + has_workers:zones_a_ln_emp_50min_transit + nodes_drv_drv_60min_jobs
+    + persons:nodes_walk_ln_popden + nodes_walk_ave_lot_sqft + is_young:zones_empden
+    + is_race2:nodes_walk_percent_race2 + ln_income:nodes_walk_ln_popden + zones_transit_jobs_30min
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm200003.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm200003.yaml
@@ -20,12 +20,8 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- has_children:nodes_drv_elem_school_perf
-- ln_income:nodes_walk_ln_popden
-- stories
-- ln_income:sqft_price_res
-- nodes_walk_percent_mid_income
+model_expression: has_children:nodes_drv_elem_school_perf + ln_income:nodes_walk_ln_popden
+    + stories + ln_income:sqft_price_res + nodes_walk_percent_mid_income
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm200005.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm200005.yaml
@@ -20,19 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- zones_logsum_job_low_income
-- has_children:nodes_walk_percent_hh_with_children
-- improvement_value
-- nodes_drv_drv_60min_jobs
-- building_type_id_is_82
-- persons:nodes_walk_ln_popden
-- building_age_le_10
-- is_race2:nodes_walk_percent_race2
-- is_young:nodes_walk_retail_jobs
-- ln_income:nodes_walk_ln_popden
-- nodes_walk_ave_unit_sqft
-- zones_transit_jobs_30min
+model_expression: zones_logsum_job_low_income + has_children:nodes_walk_percent_hh_with_children
+    + improvement_value + nodes_drv_drv_60min_jobs + building_type_id_is_82 + persons:nodes_walk_ln_popden
+    + building_age_le_10 + is_race2:nodes_walk_percent_race2 + is_young:nodes_walk_retail_jobs
+    + ln_income:nodes_walk_ln_popden + nodes_walk_ave_unit_sqft + zones_transit_jobs_30min
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm200093.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm200093.yaml
@@ -20,17 +20,9 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- residential_units
-- b_is_pre_1945
-- has_children:nodes_walk_percent_hh_with_children
-- building_type_id_is_83
-- b_total_jobs
-- nodes_walk_lowinc_hhs
-- nodes_walk_ave_lot_sqft
-- is_young:zones_empden
-- zones_logsum_pop_high_income
-- ln_income:nodes_walk_ln_popden
+model_expression: residential_units + b_is_pre_1945 + has_children:nodes_walk_percent_hh_with_children
+    + building_type_id_is_83 + b_total_jobs + nodes_walk_lowinc_hhs + nodes_walk_ave_lot_sqft
+    + is_young:zones_empden + zones_logsum_pop_high_income + ln_income:nodes_walk_ln_popden
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm200099.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm200099.yaml
@@ -20,17 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- zones_logsum_job_high_income
-- building_age_gt_100
-- nodes_drv_drv_45min_jobs
-- vacant_residential_units
-- persons:nodes_walk_ln_popden
-- is_young:zones_empden
-- is_race2:nodes_walk_percent_race2
-- has_workers:nodes_drv_drv_45min_jobs
-- ln_income:nodes_walk_ln_popden
-- parcels_total_units
+model_expression: zones_logsum_job_high_income + building_age_gt_100 + nodes_drv_drv_45min_jobs
+    + vacant_residential_units + persons:nodes_walk_ln_popden + is_young:zones_empden
+    + is_race2:nodes_walk_percent_race2 + has_workers:nodes_drv_drv_45min_jobs + ln_income:nodes_walk_ln_popden
+    + parcels_total_units
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm200115.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm200115.yaml
@@ -20,13 +20,8 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- zones_logsum_pop_low_income
-- persons:nodes_walk_ln_popden
-- has_workers:nodes_drv_drv_45min_jobs
-- ln_income:nodes_walk_ln_popden
-- crime_ucr_rate
-- zones_transit_jobs_30min
+model_expression: zones_logsum_pop_low_income + persons:nodes_walk_ln_popden + has_workers:nodes_drv_drv_45min_jobs
+    + ln_income:nodes_walk_ln_popden + crime_ucr_rate + zones_transit_jobs_30min
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm200125.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm200125.yaml
@@ -20,18 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- walk_nearest_healthcenter
-- has_children:nodes_walk_percent_hh_with_children
-- vacant_residential_units
-- nodes_walk_sum_residential_units
-- building_type_id_is_82
-- is_race1:nodes_walk_percent_race1
-- nodes_walk_ave_lot_sqft
-- ln_income:sqft_price_res
-- is_young:zones_empden
-- ln_income:nodes_walk_ln_popden
-- nodes_drv_drv_30min_jobs
+model_expression: walk_nearest_healthcenter + has_children:nodes_walk_percent_hh_with_children
+    + vacant_residential_units + nodes_walk_sum_residential_units + building_type_id_is_82
+    + is_race1:nodes_walk_percent_race1 + nodes_walk_ave_lot_sqft + ln_income:sqft_price_res
+    + is_young:zones_empden + ln_income:nodes_walk_ln_popden + nodes_drv_drv_30min_jobs
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm200147.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm200147.yaml
@@ -20,12 +20,9 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- is_young:nodes_walk_retail_jobs
-- ln_income:nodes_walk_ln_popden
-- has_children:nodes_walk_percent_hh_with_children
-- is_race1:nodes_walk_percent_race1
-- nodes_drv_drv_15min_retail_jobs
+model_expression: is_young:nodes_walk_retail_jobs + ln_income:nodes_walk_ln_popden
+    + has_children:nodes_walk_percent_hh_with_children + is_race1:nodes_walk_percent_race1
+    + nodes_drv_drv_15min_retail_jobs
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm200161.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm200161.yaml
@@ -20,16 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- year_built
-- has_children:nodes_walk_percent_hh_with_children
-- nodes_walk_sum_residential_units
-- nodes_walk_percent_low_income
-- is_race2:nodes_walk_percent_race2
-- has_workers:nodes_drv_drv_45min_jobs
-- ln_income:nodes_walk_ln_popden
-- is_young:nodes_walk_retail_jobs
-- zones_a_ln_retail_emp_15min_drive_alone
+model_expression: year_built + has_children:nodes_walk_percent_hh_with_children +
+    nodes_walk_sum_residential_units + nodes_walk_percent_low_income + is_race2:nodes_walk_percent_race2
+    + has_workers:nodes_drv_drv_45min_jobs + ln_income:nodes_walk_ln_popden + is_young:nodes_walk_retail_jobs
+    + zones_a_ln_retail_emp_15min_drive_alone
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm300003.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm300003.yaml
@@ -20,14 +20,9 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- zones_logsum_job_high_income
-- has_children:nodes_walk_percent_hh_with_children
-- is_race4:nodes_walk_percent_race4
-- nodes_walk_ave_lot_sqft
-- ln_income:sqft_price_res
-- ln_income:nodes_walk_ln_popden
-- crime_ucr_rate
+model_expression: zones_logsum_job_high_income + has_children:nodes_walk_percent_hh_with_children
+    + is_race4:nodes_walk_percent_race4 + nodes_walk_ave_lot_sqft + ln_income:sqft_price_res
+    + ln_income:nodes_walk_ln_popden + crime_ucr_rate
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm300005.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm300005.yaml
@@ -20,14 +20,9 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- residential_units
-- zones_logsum_pop_high_income
-- persons:nodes_walk_ln_popden
-- drv_nearest_urgentcare
-- ln_income:nodes_walk_ln_popden
-- nodes_walk_ave_unit_sqft
-- parcel_sqft
+model_expression: residential_units + zones_logsum_pop_high_income + persons:nodes_walk_ln_popden
+    + drv_nearest_urgentcare + ln_income:nodes_walk_ln_popden + nodes_walk_ave_unit_sqft
+    + parcel_sqft
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm300093.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm300093.yaml
@@ -20,13 +20,8 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- zones_logsum_pop_high_income
-- nodes_walk_sum_residential_units
-- stories
-- hhsize_gt_2:building_type_id_is_81
-- nodes_walk_ave_lot_sqft
-- ln_income:nodes_walk_ln_popden
+model_expression: zones_logsum_pop_high_income + nodes_walk_sum_residential_units
+    + stories + hhsize_gt_2:building_type_id_is_81 + nodes_walk_ave_lot_sqft + ln_income:nodes_walk_ln_popden
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm300099.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm300099.yaml
@@ -20,17 +20,9 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- nodes_walk_race_1_hhs
-- has_children:nodes_walk_percent_hh_with_children
-- drv_nearest_library
-- building_type_id_is_82
-- nodes_drv_drv_45min_jobs
-- is_race1:nodes_walk_percent_race1
-- vacant_job_spaces
-- nodes_walk_ave_lot_sqft
-- is_young:zones_empden
-- ln_income:nodes_walk_ln_popden
+model_expression: nodes_walk_race_1_hhs + has_children:nodes_walk_percent_hh_with_children
+    + drv_nearest_library + building_type_id_is_82 + nodes_drv_drv_45min_jobs + is_race1:nodes_walk_percent_race1
+    + vacant_job_spaces + nodes_walk_ave_lot_sqft + is_young:zones_empden + ln_income:nodes_walk_ln_popden
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm300115.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm300115.yaml
@@ -20,12 +20,8 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- walk_nearest_library
-- is_race1:nodes_walk_percent_race1
-- residential_units
-- ln_income:sqft_per_unit
-- nodes_walk_percent_mid_income
+model_expression: walk_nearest_library + is_race1:nodes_walk_percent_race1 + residential_units
+    + ln_income:sqft_per_unit + nodes_walk_percent_mid_income
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm300125.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm300125.yaml
@@ -20,15 +20,9 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- has_children:nodes_walk_percent_hh_with_children
-- crime_other_rate
-- building_type_id_is_82
-- nodes_walk_ave_lot_sqft
-- is_young:zones_empden
-- is_race2:nodes_walk_percent_race2
-- parcels_total_units
-- ln_income:nodes_walk_ln_popden
+model_expression: has_children:nodes_walk_percent_hh_with_children + crime_other_rate
+    + building_type_id_is_82 + nodes_walk_ave_lot_sqft + is_young:zones_empden + is_race2:nodes_walk_percent_race2
+    + parcels_total_units + ln_income:nodes_walk_ln_popden
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm300147.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm300147.yaml
@@ -20,12 +20,8 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- ln_income:nodes_walk_ave_income
-- residential_units
-- nodes_walk_quarter_mile_to_transit
-- hhsize_gt_2:building_type_id_is_81
-- building_type_id_is_82
+model_expression: ln_income:nodes_walk_ave_income + residential_units + nodes_walk_quarter_mile_to_transit
+    + hhsize_gt_2:building_type_id_is_81 + building_type_id_is_82
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm300161.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm300161.yaml
@@ -20,16 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- has_children:nodes_walk_percent_hh_with_children
-- has_workers:zones_a_ln_emp_50min_transit
-- nodes_walk_sum_residential_units
-- nodes_walk_ave_lot_sqft
-- nodes_walk_sum_nonresidential_units
-- is_young:zones_empden
-- ln_income:nodes_walk_ln_popden
-- zones_transit_jobs_30min
-- nodes_walk_percent_mid_income
+model_expression: has_children:nodes_walk_percent_hh_with_children + has_workers:zones_a_ln_emp_50min_transit
+    + nodes_walk_sum_residential_units + nodes_walk_ave_lot_sqft + nodes_walk_sum_nonresidential_units
+    + is_young:zones_empden + ln_income:nodes_walk_ln_popden + zones_transit_jobs_30min
+    + nodes_walk_percent_mid_income
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm400003.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm400003.yaml
@@ -20,13 +20,9 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- has_children:nodes_drv_elem_school_perf
-- ln_income:nodes_walk_ave_income
-- is_race4:nodes_walk_percent_race4
-- persons:sqft_per_unit
-- nodes_walk_population
-- zones_a_ln_emp_26min_drive_alone
+model_expression: has_children:nodes_drv_elem_school_perf + ln_income:nodes_walk_ave_income
+    + is_race4:nodes_walk_percent_race4 + persons:sqft_per_unit + nodes_walk_population
+    + zones_a_ln_emp_26min_drive_alone
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm400005.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm400005.yaml
@@ -20,20 +20,11 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- has_children:nodes_walk_percent_hh_with_children
-- improvement_value
-- has_workers:zones_a_ln_emp_50min_transit
-- ln_income:nodes_walk_ave_income
-- b_ln_parcel_sqft
-- nodes_drv_drv_60min_jobs
-- building_age_gt_100
-- is_race1:nodes_walk_percent_race1
-- persons:nodes_walk_ln_popden
-- nodes_walk_race_4_hhs
-- is_young:nodes_walk_retail_jobs
-- nodes_walk_ave_unit_sqft
-- parcels_total_units
+model_expression: has_children:nodes_walk_percent_hh_with_children + improvement_value
+    + has_workers:zones_a_ln_emp_50min_transit + ln_income:nodes_walk_ave_income +
+    b_ln_parcel_sqft + nodes_drv_drv_60min_jobs + building_age_gt_100 + is_race1:nodes_walk_percent_race1
+    + persons:nodes_walk_ln_popden + nodes_walk_race_4_hhs + is_young:nodes_walk_retail_jobs
+    + nodes_walk_ave_unit_sqft + parcels_total_units
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm400093.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm400093.yaml
@@ -20,15 +20,9 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- residential_units
-- has_children:nodes_walk_percent_hh_with_children
-- nodes_drv_drv_60min_jobs
-- ln_income:nodes_walk_ave_income
-- nodes_walk_sum_residential_units
-- is_race1:nodes_walk_percent_race1
-- persons:sqft_per_unit
-- zones_logsum_pop_low_income
+model_expression: residential_units + has_children:nodes_walk_percent_hh_with_children
+    + nodes_drv_drv_60min_jobs + ln_income:nodes_walk_ave_income + nodes_walk_sum_residential_units
+    + is_race1:nodes_walk_percent_race1 + persons:sqft_per_unit + zones_logsum_pop_low_income
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm400099.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm400099.yaml
@@ -20,17 +20,10 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- building_type_id_is_84
-- residential_units
-- ln_income:nodes_walk_ave_income
-- is_race4:nodes_walk_percent_race4
-- building_type_id_is_83
-- nodes_walk_population
-- has_children:sqft_per_unit
-- persons:nodes_walk_ln_popden
-- is_young:zones_empden
-- crime_ucr_rate
+model_expression: building_type_id_is_84 + residential_units + ln_income:nodes_walk_ave_income
+    + is_race4:nodes_walk_percent_race4 + building_type_id_is_83 + nodes_walk_population
+    + has_children:sqft_per_unit + persons:nodes_walk_ln_popden + is_young:zones_empden
+    + crime_ucr_rate
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm400115.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm400115.yaml
@@ -20,14 +20,9 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- ln_income:nodes_walk_ave_income
-- persons:sqft_per_unit
-- has_children:sqft_per_unit
-- vacant_residential_units
-- nodes_walk_ave_lot_sqft
-- building_type_id_is_84
-- nodes_walk_race_3_hhs
+model_expression: ln_income:nodes_walk_ave_income + persons:sqft_per_unit + has_children:sqft_per_unit
+    + vacant_residential_units + nodes_walk_ave_lot_sqft + building_type_id_is_84
+    + nodes_walk_race_3_hhs
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm400125.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm400125.yaml
@@ -20,16 +20,9 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- zones_logsum_job_high_income
-- walk_nearest_healthcenter
-- has_children:nodes_walk_percent_hh_with_children
-- ln_income:nodes_walk_ave_income
-- persons:sqft_per_unit
-- building_age_le_10
-- is_young:zones_empden
-- is_race2:nodes_walk_percent_race2
-- parcels_total_units
+model_expression: zones_logsum_job_high_income + walk_nearest_healthcenter + has_children:nodes_walk_percent_hh_with_children
+    + ln_income:nodes_walk_ave_income + persons:sqft_per_unit + building_age_le_10
+    + is_young:zones_empden + is_race2:nodes_walk_percent_race2 + parcels_total_units
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm400147.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm400147.yaml
@@ -20,12 +20,8 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- ln_income:nodes_walk_ave_income
-- residential_units
-- has_children:nodes_walk_percent_hh_with_children
-- persons:sqft_per_unit
-- has_workers:zones_a_ln_emp_50min_transit
+model_expression: ln_income:nodes_walk_ave_income + residential_units + has_children:nodes_walk_percent_hh_with_children
+    + persons:sqft_per_unit + has_workers:zones_a_ln_emp_50min_transit
 
 fitted: true
 

--- a/configs/hlcm/large_area_income_quartile/hlcm400161.yaml
+++ b/configs/hlcm/large_area_income_quartile/hlcm400161.yaml
@@ -20,19 +20,11 @@ estimation_sample_size: 2000
 
 prediction_sample_size: 100
 
-model_expression:
-- building_type_id_is_84
-- year_built
-- has_children:nodes_walk_percent_hh_with_children
-- has_workers:zones_a_ln_emp_50min_transit
-- ln_income:nodes_walk_ave_income
-- b_ln_parcel_sqft
-- is_race4:nodes_walk_percent_race4
-- persons:sqft_per_unit
-- vacant_job_spaces
-- nodes_walk_sum_residential_units
-- is_young:zones_empden
-- nodes_walk_race_4_hhs
+model_expression: building_type_id_is_84 + year_built + has_children:nodes_walk_percent_hh_with_children
+    + has_workers:zones_a_ln_emp_50min_transit + ln_income:nodes_walk_ave_income +
+    b_ln_parcel_sqft + is_race4:nodes_walk_percent_race4 + persons:sqft_per_unit +
+    vacant_job_spaces + nodes_walk_sum_residential_units + is_young:zones_empden +
+    nodes_walk_race_4_hhs
 
 fitted: true
 


### PR DESCRIPTION
Autospec outputs model configs with model expressions in the form of a list of variable names.  This re-formats the HLCM model expressions as a patsy string.