### PR TITLE
Proforma/developer config changes for sub-optimal proposals

### DIFF
--- a/configs/nonres_developer.yaml
+++ b/configs/nonres_developer.yaml
@@ -7,3 +7,7 @@ max_parcel_size: 2000000
 drop_after_build: True
 
 residential: False
+
+keep_suboptimal: True
+
+noise_scale: 100000

--- a/configs/proforma.yaml
+++ b/configs/proforma.yaml
@@ -227,3 +227,5 @@ forms_to_test:
 pass_through: []
 
 simple_zoning: false
+
+proposals_to_keep: 3

--- a/configs/res_developer.yaml
+++ b/configs/res_developer.yaml
@@ -7,3 +7,7 @@ max_parcel_size: 10000000
 drop_after_build: True
 
 residential: True
+
+keep_suboptimal: True
+
+noise_scale: 100000


### PR DESCRIPTION
This PR makes additions to the proforma / developer config files that facilitates the retention/consideration of sub-optimal proposals (less profitable proposals for a given form, less profitable forms for a given parcel).   To run a simulation with these additions, please use the `keep-suboptimal` branch of udst/developer (see the open PR on that repo) and the `suboptimal-proposals` branch of urbansim/urbansim_parcels.